### PR TITLE
Preserve cell styles from JSON sources

### DIFF
--- a/dist/stundenplan-card.js
+++ b/dist/stundenplan-card.js
@@ -985,8 +985,8 @@ const D = (nt = class extends q {
       const l = (a?.time ?? a?.[s] ?? a?.[n] ?? a?.[r] ?? "").toString(), d = yt(l), _ = Array.from({ length: i.length }, (g, f) => {
         const p = (i[f] ?? "").toString();
         return (a?.[p] ?? "").toString();
-      }), u = (a?.start ?? "").toString().trim() || d.start, h = (a?.end ?? "").toString().trim() || d.end;
-      return { time: l, start: u || void 0, end: h || void 0, cells: _ };
+      }), u = (a?.start ?? "").toString().trim() || d.start, h = (a?.end ?? "").toString().trim() || d.end, f = Array.isArray(a?.cell_styles) ? a.cell_styles : [], p = Array.from({ length: i.length }, (g, m) => Xe(f[m])), x = { time: l, start: u || void 0, end: h || void 0, cells: _ };
+      return p.some((g) => !!g) && (x.cell_styles = p), x;
     });
     return o.length ? o : null;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stundenplan-card",
-  "version": "3.1.6",
+  "version": "3.2.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stundenplan-card",
-      "version": "3.1.6",
+      "version": "3.2.5-beta.1",
       "devDependencies": {
         "esbuild": "^0.27.2",
         "lit": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stundenplan-card",
-  "version": "3.2.4",
+  "version": "3.2.5-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/stundenplan-card.ts
+++ b/src/stundenplan-card.ts
@@ -1036,8 +1036,8 @@ const v = (D = class extends U {
       const l = (o?.time ?? o?.[tkCfg] ?? o?.[tkAlt1] ?? o?.[tkAlt2] ?? "").toString(), a = mt(l), c = Array.from({ length: s.length }, (u, g) => {
         const O = (s[g] ?? "").toString();
         return (o?.[O] ?? "").toString();
-      }), _ = (o?.start ?? "").toString().trim() || a.start, h = (o?.end ?? "").toString().trim() || a.end;
-      return { time: l, start: _ || void 0, end: h || void 0, cells: c };
+      }), _ = (o?.start ?? "").toString().trim() || a.start, h = (o?.end ?? "").toString().trim() || a.end, g = Array.isArray(o?.cell_styles) ? o.cell_styles : [], O = Array.from({ length: s.length }, (u, W) => De(g[W])), B = { time: l, start: _ || void 0, end: h || void 0, cells: c };
+      return O.some((u) => !!u) && (B.cell_styles = O), B;
     });
     return n.length ? n : null;
   }
@@ -3326,5 +3326,4 @@ export {
   Xt as StundenplanCard,
   ht as StundenplanCardEditor
 };
-
 


### PR DESCRIPTION
External JSON/sensor sources can already provide row data, but buildRowsFromArray discarded cell_styles while manual rows preserved them. This keeps sanitized cell_styles from JSON-derived rows as well.

This is useful for integrations that want to mark substitutions, cancelled lessons, or other cell-level states without requiring manual editing.

Validation: node --check dist/stundenplan-card.js