### PR TITLE
Support focused-day times from JSON rows

### DIFF
--- a/dist/stundenplan-card.js
+++ b/dist/stundenplan-card.js
@@ -862,13 +862,13 @@ const D = (nt = class extends q {
     const t = nt.getStubConfig(), i = Array.isArray(e.days) && e.days.length ? e.days.map((y) => (y ?? "").toString()) : ["Mo", "Di", "Mi", "Do", "Fr"], s = (Array.isArray(e.rows) ? e.rows : []).map((y) => {
       if (G(y))
         return { break: !0, time: (y.time ?? "").toString(), label: (y.label ?? "Pause").toString() };
-      const A = Array.isArray(y?.cells) ? y.cells : [], T = Array.from({ length: i.length }, (N, B) => (A[B] ?? "").toString()), H = Array.isArray(y?.cell_styles) ? y.cell_styles : [], tt = Array.from({ length: i.length }, (N, B) => oe(H[B])), ut = (y?.time ?? "").toString(), et = yt(ut), Nt = (y?.start ?? "").toString().trim(), jt = (y?.end ?? "").toString().trim(), gt = {
+      const A = Array.isArray(y?.cells) ? y.cells : [], T = Array.from({ length: i.length }, (N, B) => (A[B] ?? "").toString()), H = Array.isArray(y?.cell_styles) ? y.cell_styles : [], tt = Array.from({ length: i.length }, (N, B) => oe(H[B])), B = Array.isArray(y?.cell_times) ? Array.from({ length: i.length }, (N, K) => this.normalizeCellTime(y?.cell_times?.[K])) : [], ut = (y?.time ?? "").toString(), et = yt(ut), Nt = (y?.start ?? "").toString().trim(), jt = (y?.end ?? "").toString().trim(), gt = {
         time: ut,
         start: Nt || et.start || void 0,
         end: jt || et.end || void 0,
         cells: T
       };
-      return tt.some((N) => !!N) && (gt.cell_styles = tt), gt;
+      return tt.some((N) => !!N) && (gt.cell_styles = tt), B.some((N) => !!N) && (gt.cell_times = B), gt;
     }), n = ((e.view_mode ?? "week") + "").toString().trim(), r = n === "rolling" ? "rolling" : "week", a = ((e.display_mode ?? "default") + "").toString().trim(), o = a === "compact" ? "compact" : "default", l = Number(e.days_ahead), d = Number.isFinite(l) ? Math.max(0, Math.min(6, Math.floor(l))) : 0, _ = ((e.rolling_switch_mode ?? t.rolling_switch_mode ?? "midnight") + "").toString().trim(), g = _ === "after_last_lesson" || _ === "fixed_time" ? _ : "midnight", h = ((e.rolling_switch_time ?? t.rolling_switch_time ?? "") + "").toString().trim(), p = ((e.week_mode ?? t.week_mode) + "").toString().trim(), f = p === "kw_parity" || p === "week_map" || p === "off" ? p : "off", u = (() => {
       const y = ((e.source_type ?? "") + "").toString().trim();
       if (y === "manual" || y === "entity" || y === "json" || y === "sensor") return y;
@@ -973,6 +973,16 @@ const D = (nt = class extends q {
     const s = this.hass.states[i], n = (t ?? "").toString().trim(), r = n ? s.attributes?.[n] : s.state;
     return this.parseAnyJson(r);
   }
+  normalizeCellTime(e) {
+    if (e == null) return null;
+    if (typeof e == "string") {
+      const t = e.trim(), i = yt(t);
+      return t ? { time: t, start: i.start, end: i.end } : null;
+    }
+    if (typeof e != "object") return null;
+    const t = (e.time ?? "").toString().trim(), i = yt(t), s = (e.start ?? "").toString().trim() || i.start, n = (e.end ?? "").toString().trim() || i.end;
+    return t || s || n ? { time: t || (s && n ? `${s}-${n}` : ""), start: s || void 0, end: n || void 0 } : null;
+  }
   buildRowsFromArray(e, t) {
     if (!Array.isArray(t)) return null;
     const i = e.days ?? [], s = (e.source_time_key ?? "time").toString().trim(), n = "Stunde", r = "time", a = t.map((o) => {
@@ -985,8 +995,8 @@ const D = (nt = class extends q {
       const l = (o?.time ?? o?.[s] ?? o?.[n] ?? o?.[r] ?? "").toString(), d = yt(l), _ = Array.isArray(o?.cells) ? Array.from({ length: i.length }, (u, m) => (o?.cells?.[m] ?? "").toString()) : Array.from({ length: i.length }, (u, m) => {
         const x = (i[m] ?? "").toString();
         return (o?.[x] ?? "").toString();
-      }), g = Array.isArray(o?.cell_styles) ? Array.from({ length: i.length }, (u, m) => oe(o?.cell_styles?.[m])) : [], h = (o?.start ?? "").toString().trim() || d.start, p = (o?.end ?? "").toString().trim() || d.end, f = { time: l, start: h || void 0, end: p || void 0, cells: _ };
-      return g.some((u) => !!u) && (f.cell_styles = g), f;
+      }), g = Array.isArray(o?.cell_styles) ? Array.from({ length: i.length }, (u, m) => oe(o?.cell_styles?.[m])) : [], h = Array.isArray(o?.cell_times) ? Array.from({ length: i.length }, (u, m) => this.normalizeCellTime(o?.cell_times?.[m])) : [], p = (o?.start ?? "").toString().trim() || d.start, f = (o?.end ?? "").toString().trim() || d.end, v = { time: l, start: p || void 0, end: f || void 0, cells: _ };
+      return g.some((u) => !!u) && (v.cell_styles = g), h.some((u) => !!u) && (v.cell_times = h), v;
     });
     return a.length ? a : null;
   }
@@ -1369,7 +1379,7 @@ const D = (nt = class extends q {
     return d(n);
   }
   renderCardLayout(e, t = null, i = !1) {
-    const s = this._rowsCache, n = this.getHeaderDaysFromEntity(e), r = this.getTodayIndex(e.days ?? [], n), a = ((t ?? this._uiViewMode ?? e.view_mode ?? "week") + "").toString(), o = Number(e.days_ahead), l = Number.isFinite(o) ? Math.max(0, Math.min(6, Math.floor(o))) : 0, d = "1px solid var(--divider-color)", _ = le(e.highlight_today_color ?? "", 0.12), g = le(e.highlight_current_color ?? "", 0.18), h = (e.highlight_current_text_color ?? "").toString().trim(), p = (e.highlight_current_time_text_color ?? "").toString().trim(), f = e.week_mode !== "off", u = f ? this.getActiveWeek(e) : null, m = this.getWeekOffsetValue(e), x = (e.source_type ?? "manual").toString(), S = !i && (e.week_offset_entity ?? "").trim().length > 0, k = S && (x === "entity" || x === "sensor" && (e.week_mode ?? "off") !== "off"), v = n && n.length >= (e.days?.length ?? 0) ? n : null, y = this.getHeaderUpdatedFromEntity(e), A = this.getBaseDate(e), T = this.mondayOfWeek(A), H = this.normalizeTapAction(e.tap_action), tt = i ? "default" : e.display_mode ?? "default", ut = `${tt === "compact" ? "compact" : ""}${!i && H.action !== "none" ? " tappable" : ""}${i ? " popupCard" : ""}`, et = e.show_title !== !1 && (e.title ?? "").toString().trim().length > 0, Nt = this.getTitleStyle(e), jt = et || f || k, gt = a === "rolling" && (i || !k || (m ?? 0) === 0), N = gt ? this.getRollingVisibleSlots(e, l) : [], B = N.length ? N.map((w) => w.orig) : Array.from({ length: e.days?.length ?? 0 }, (w, b) => b), pt = B.map((w) => e.days[w]), L = N.length ? N.map((w) => w.date) : null, Yt = (() => {
+    const s = this._rowsCache, n = this.getHeaderDaysFromEntity(e), r = this.getTodayIndex(e.days ?? [], n), a = ((t ?? this._uiViewMode ?? e.view_mode ?? "week") + "").toString(), o = Number(e.days_ahead), l = Number.isFinite(o) ? Math.max(0, Math.min(6, Math.floor(o))) : 0, d = "1px solid var(--divider-color)", _ = le(e.highlight_today_color ?? "", 0.12), g = le(e.highlight_current_color ?? "", 0.18), h = (e.highlight_current_text_color ?? "").toString().trim(), p = (e.highlight_current_time_text_color ?? "").toString().trim(), f = e.week_mode !== "off", u = f ? this.getActiveWeek(e) : null, m = this.getWeekOffsetValue(e), x = (e.source_type ?? "manual").toString(), S = !i && (e.week_offset_entity ?? "").trim().length > 0, k = S && (x === "entity" || x === "sensor" && (e.week_mode ?? "off") !== "off"), v = n && n.length >= (e.days?.length ?? 0) ? n : null, y = this.getHeaderUpdatedFromEntity(e), A = this.getBaseDate(e), T = this.mondayOfWeek(A), H = this.normalizeTapAction(e.tap_action), tt = i ? "default" : e.display_mode ?? "default", ut = `${tt === "compact" ? "compact" : ""}${!i && H.action !== "none" ? " tappable" : ""}${i ? " popupCard" : ""}`, et = e.show_title !== !1 && (e.title ?? "").toString().trim().length > 0, Nt = this.getTitleStyle(e), jt = et || f || k, gt = a === "rolling" && (i || !k || (m ?? 0) === 0), N = gt ? this.getRollingVisibleSlots(e, l) : [], B = N.length ? N.map((w) => w.orig) : Array.from({ length: e.days?.length ?? 0 }, (w, b) => b), pt = B.map((w) => e.days[w]), L = N.length ? N.map((w) => w.date) : null, Q = N.length ? N[0].orig : r >= 0 ? r : B[0] ?? 0, Yt = (() => {
       const w = /* @__PURE__ */ new Map();
       return !v || !y || v.forEach((b, M) => {
         const J = y[M];
@@ -1440,13 +1450,13 @@ const D = (nt = class extends q {
                     </tr>
                   `;
       }
-      const b = w, M = b.cells ?? [], J = b.cell_styles ?? [], j = !!b.start && !!b.end && this.isNowBetween(b.start, b.end), _t = r >= 0 ? M[r] ?? "" : "", ft = r >= 0 ? this.filterCellText(_t, e) : "", Se = r >= 0 ? wt(ft) : !1, Pt = !(e.free_only_column_highlight && Se), Jt = yt(b.time), ke = !!(Jt.start && Jt.end), Kt = !ke && b.start && b.end ? `${b.start}–${b.end}` : "";
+      const b = w, M = b.cells ?? [], J = b.cell_styles ?? [], D = b.cell_times?.[Q] ?? null, V = D?.time || b.time, X = D?.start || b.start, Z = D?.end || b.end, j = !!X && !!Z && this.isNowBetween(X, Z), _t = r >= 0 ? M[r] ?? "" : "", ft = r >= 0 ? this.filterCellText(_t, e) : "", Se = r >= 0 ? wt(ft) : !1, Pt = !(e.free_only_column_highlight && Se), Jt = yt(V), ke = !!(Jt.start && Jt.end), Kt = !ke && X && Z ? `${X}–${Z}` : "";
       let Rt = `--sp-hl:${g};`;
       return Pt && e.highlight_current && j && (Rt += "box-shadow: inset 0 0 0 9999px var(--sp-hl);"), Pt && j && e.highlight_current_time_text && p && (Rt += `color:${p};`), c`
                   <tr>
                     <td class="time" style=${Rt}>
                       <div class="timeWrap">
-                        <div class="timeSt">${b.time}</div>
+                        <div class="timeSt">${V}</div>
                         ${Kt ? c`<div class="timeHm">${Kt}</div>` : c``}
                       </div>
                     </td>

--- a/src/stundenplan-card.ts
+++ b/src/stundenplan-card.ts
@@ -887,13 +887,13 @@ const v = (D = class extends U {
     const e = D.getStubConfig(), s = Array.isArray(t.days) && t.days.length ? t.days.map((h) => (h ?? "").toString()) : ["Mo", "Di", "Mi", "Do", "Fr"], n = (Array.isArray(t.rows) ? t.rows : []).map((h) => {
       if (ct(h))
         return { break: !0, time: (h.time ?? "").toString(), label: (h.label ?? "Pause").toString() };
-      const p = Array.isArray(h?.cells) ? h.cells : [], u = Array.from({ length: s.length }, (w, x) => (p[x] ?? "").toString()), g = Array.isArray(h?.cell_styles) ? h.cell_styles : [], O = Array.from({ length: s.length }, (w, x) => De(g[x])), B = (h?.time ?? "").toString(), y = mt(B), m = (h?.start ?? "").toString().trim(), W = (h?.end ?? "").toString().trim(), b = {
+      const p = Array.isArray(h?.cells) ? h.cells : [], u = Array.from({ length: s.length }, (w, x) => (p[x] ?? "").toString()), g = Array.isArray(h?.cell_styles) ? h.cell_styles : [], O = Array.from({ length: s.length }, (w, x) => De(g[x])), x = Array.isArray(h?.cell_times) ? Array.from({ length: s.length }, (w, y) => this.normalizeCellTime(h?.cell_times?.[y])) : [], B = (h?.time ?? "").toString(), y = mt(B), m = (h?.start ?? "").toString().trim(), W = (h?.end ?? "").toString().trim(), b = {
         time: B,
         start: m || y.start || void 0,
         end: W || y.end || void 0,
         cells: u
       };
-      return O.some((w) => !!w) && (b.cell_styles = O), b;
+      return O.some((w) => !!w) && (b.cell_styles = O), x.some((w) => !!w) && (b.cell_times = x), b;
     }), vmRaw = ((t.view_mode ?? "week") + "").toString().trim(), vm = vmRaw === "rolling" ? "rolling" : "week", displayModeRaw = ((t.display_mode ?? "default") + "").toString().trim(), displayMode = displayModeRaw === "compact" ? "compact" : "default", da = Number(t.days_ahead), daysAhead = Number.isFinite(da) ? Math.max(0, Math.min(6, Math.floor(da))) : 0, rollingSwitchRaw = ((t.rolling_switch_mode ?? e.rolling_switch_mode ?? "midnight") + "").toString().trim(), rollingSwitchMode = rollingSwitchRaw === "after_last_lesson" || rollingSwitchRaw === "fixed_time" ? rollingSwitchRaw : "midnight", rollingSwitchTime = ((t.rolling_switch_time ?? e.rolling_switch_time ?? "") + "").toString().trim(), o = ((t.week_mode ?? e.week_mode) + "").toString().trim(), l = o === "kw_parity" || o === "week_map" || o === "off" ? o : "off", f = (() => {
       const raw = ((t.source_type ?? "") + "").toString().trim();
       if (raw === "manual" || raw === "entity" || raw === "json" || raw === "sensor") return raw;
@@ -1020,6 +1020,16 @@ const v = (D = class extends U {
     const i = this.hass.states[s], n = (e ?? "").toString().trim(), o = n ? i.attributes?.[n] : i.state;
     return this.parseAnyJson(o);
   }
+  normalizeCellTime(t) {
+    if (t == null) return null;
+    if (typeof t == "string") {
+      const e = t.trim(), s = mt(e);
+      return e ? { time: e, start: s.start, end: s.end } : null;
+    }
+    if (typeof t != "object") return null;
+    const e = (t.time ?? "").toString().trim(), s = mt(e), i = (t.start ?? "").toString().trim() || s.start, n = (t.end ?? "").toString().trim() || s.end;
+    return e || i || n ? { time: e || (i && n ? `${i}-${n}` : ""), start: i || void 0, end: n || void 0 } : null;
+  }
   buildRowsFromArray(t, e) {
     if (!Array.isArray(e)) return null;
     const s = t.days ?? [];
@@ -1036,8 +1046,8 @@ const v = (D = class extends U {
       const l = (o?.time ?? o?.[tkCfg] ?? o?.[tkAlt1] ?? o?.[tkAlt2] ?? "").toString(), a = mt(l), c = Array.isArray(o?.cells) ? Array.from({ length: s.length }, (u, g) => (o?.cells?.[g] ?? "").toString()) : Array.from({ length: s.length }, (u, g) => {
         const O = (s[g] ?? "").toString();
         return (o?.[O] ?? "").toString();
-      }), _ = Array.isArray(o?.cell_styles) ? Array.from({ length: s.length }, (u, g) => De(o?.cell_styles?.[g])) : [], h = (o?.start ?? "").toString().trim() || a.start, f = (o?.end ?? "").toString().trim() || a.end, p = { time: l, start: h || void 0, end: f || void 0, cells: c };
-      return _.some((u) => !!u) && (p.cell_styles = _), p;
+      }), _ = Array.isArray(o?.cell_styles) ? Array.from({ length: s.length }, (u, g) => De(o?.cell_styles?.[g])) : [], h = Array.isArray(o?.cell_times) ? Array.from({ length: s.length }, (u, g) => this.normalizeCellTime(o?.cell_times?.[g])) : [], f = (o?.start ?? "").toString().trim() || a.start, p = (o?.end ?? "").toString().trim() || a.end, x = { time: l, start: f || void 0, end: p || void 0, cells: c };
+      return _.some((u) => !!u) && (x.cell_styles = _), h.some((u) => !!u) && (x.cell_times = h), x;
     });
     return n.length ? n : null;
   }
@@ -1577,6 +1587,7 @@ getRowsResolved(t) {
         idxs = rollingSlots.length ? rollingSlots.map((y) => y.orig) : Array.from({ length: t.days?.length ?? 0 }, (y, m) => m),
         daysVis = idxs.map((y) => t.days[y]),
         rollingDates = rollingSlots.length ? rollingSlots.map((y) => y.date) : null,
+        focusDayIndex = rollingSlots.length ? rollingSlots[0].orig : s >= 0 ? s : idxs[0] ?? 0,
         updMap = (() => {
           const y = /* @__PURE__ */ new Map();
           if (!g || !upd) return y;
@@ -1646,15 +1657,15 @@ getRowsResolved(t) {
                     </tr>
                   `;
       }
-      const m = y, W = m.cells ?? [], b = m.cell_styles ?? [], w = !!m.start && !!m.end && this.isNowBetween(m.start, m.end), x = s >= 0 ? W[s] ?? "" : "", te = s >= 0 ? this.filterCellText(x, t) : "", ee = s >= 0 ? yt(te) : !1, pt = !(!!t.free_only_column_highlight && ee), __rng = mt(m.time),
+      const m = y, W = m.cells ?? [], b = m.cell_styles ?? [], cellTime = m.cell_times?.[focusDayIndex] ?? null, displayTime = cellTime?.time || m.time, displayStart = cellTime?.start || m.start, displayEnd = cellTime?.end || m.end, w = !!displayStart && !!displayEnd && this.isNowBetween(displayStart, displayEnd), x = s >= 0 ? W[s] ?? "" : "", te = s >= 0 ? this.filterCellText(x, t) : "", ee = s >= 0 ? yt(te) : !1, pt = !(!!t.free_only_column_highlight && ee), __rng = mt(displayTime),
       __timeHasRange = !!(__rng.start && __rng.end),
-      Et = (!__timeHasRange && m.start && m.end) ? `${m.start}–${m.end}` : "";
+      Et = (!__timeHasRange && displayStart && displayEnd) ? `${displayStart}–${displayEnd}` : "";
       let gt = `--sp-hl:${o};`;
       return pt && t.highlight_current && w && (gt += "box-shadow: inset 0 0 0 9999px var(--sp-hl);"), pt && w && t.highlight_current_time_text && a && (gt += `color:${a};`), d`
                   <tr>
                     <td class="time" style=${gt}>
                       <div class="timeWrap">
-                        <div class="timeSt">${m.time}</div>
+                        <div class="timeSt">${displayTime}</div>
                         ${Et ? d`<div class="timeHm">${Et}</div>` : d``}
                       </div>
                     </td>
@@ -3326,5 +3337,3 @@ export {
   Xt as StundenplanCard,
   ht as StundenplanCardEditor
 };
-
-


### PR DESCRIPTION
JSON timetable sources can contain days with different lesson times, for example a shortened heat timetable on one day of the week. The card currently has only one time range per row, so those schedules cannot be represented without creating duplicate rows.

This adds an optional `cell_times` array alongside `cells` and `cell_styles`. Each entry accepts either a time-range string or an object with `time`, `start`, and `end`.

The shared time column uses the focused day:
- week view: today (or the first visible day when today is not present)
- rolling view: the first visible rolling day, including when it has already advanced after the last lesson or at the configured switch time

Existing JSON and manual configurations remain unchanged when `cell_times` is absent. Current-lesson highlighting uses the selected focused-day range as well.

Example:
```json
{
  "time": "08:00-08:45",
  "cells": ["Math", "English"],
  "cell_times": [
    {"start": "08:00", "end": "08:45"},
    {"start": "08:00", "end": "08:30"}
  ]
}
```

Validation: `node --check dist/stundenplan-card.js`.